### PR TITLE
Prompt Merge Handling Update

### DIFF
--- a/smartapi_mcp/server.py
+++ b/smartapi_mcp/server.py
@@ -50,6 +50,7 @@ async def merge_mcp_servers(
         api_name = re.sub(
             r"[^a-z0-9_-]", "_", getattr(server, "name", "unknown_api").lower()
         )
+        
         tools = await server.get_tools()
         if tools:
             for original_name, tool in tools.items():
@@ -62,6 +63,17 @@ async def merge_mcp_servers(
         else:
             err_msg = f"Server {server} does not have accessible tools."
             raise AttributeError(err_msg)
+        
+        # Merge prompts
+        prompts = await server.get_prompts()
+        if prompts:
+            for original_name, prompt in prompts.items():
+                # Rename the prompt by prefixing with API name
+                new_name = f"{api_name}_{original_name}"
+                prompt.name = new_name  # Modify the prompt's name attribute
+                # Add the renamed prompt to the merged instance
+                merged_mcp.add_prompt(prompt)
+            logger.debug(f"Merged {len(prompts)} prompts from {api_name}")
 
     return merged_mcp
 

--- a/smartapi_mcp/server.py
+++ b/smartapi_mcp/server.py
@@ -34,8 +34,10 @@ async def merge_mcp_servers(
     list_of_servers: list[FastMCP], merged_name: str = "merged_mcp"
 ) -> FastMCP:
     """
-    Merges a list of FastMCP instances into a single FastMCP instance by combining their
-    tools, prefixing tool names with the server's name (API name) to avoid conflicts.
+    Merges a list of FastMCP instances into
+    a single FastMCP instance by combining their
+    tools, prefixing tool names with the server's
+    name (API name) to avoid conflicts.
 
     Args:
         list_of_servers: List of FastMCP instances to merge.
@@ -50,7 +52,7 @@ async def merge_mcp_servers(
         api_name = re.sub(
             r"[^a-z0-9_-]", "_", getattr(server, "name", "unknown_api").lower()
         )
-        
+
         tools = await server.get_tools()
         if tools:
             for original_name, tool in tools.items():
@@ -63,7 +65,7 @@ async def merge_mcp_servers(
         else:
             err_msg = f"Server {server} does not have accessible tools."
             raise AttributeError(err_msg)
-        
+
         # Merge prompts
         prompts = await server.get_prompts()
         if prompts:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -234,12 +234,14 @@ async def test_merge_mcp_servers_special_characters_in_name():
     mock_tool1 = MagicMock()
     mock_tool1.name = "original_tool_1"
     mock_server1.get_tools = AsyncMock(return_value={"tool1": mock_tool1})
+    mock_server1.get_prompts = AsyncMock(return_value={})
 
     mock_server2 = MagicMock()
     mock_server2.name = "API-with-dashes_and_underscores"
     mock_tool2 = MagicMock()
     mock_tool2.name = "original_tool_2"
     mock_server2.get_tools = AsyncMock(return_value={"tool2": mock_tool2})
+    mock_server2.get_prompts = AsyncMock(return_value={})
 
     merged_server = await merge_mcp_servers([mock_server1, mock_server2])
 


### PR DESCRIPTION
Prompts are generated at runtime for each server, however they were being *skipped* in the merge process. We added prompt merge handling in the `server.py`, where we follow the same consistent name and merge format that is done previously for the tool merge. 